### PR TITLE
Re-raise the caught error with the correct stacktrace in memo

### DIFF
--- a/src/depcache.erl
+++ b/src/depcache.erl
@@ -170,9 +170,8 @@ memo(Fun, Key, MaxAge, Dep, Server) ->
                 Value1
             catch
                 ?WITH_STACKTRACE(Class, R, S)
-                    error_logger:error_msg("Error in memo ~p:~p in ~p", [Class, R, S]),
                     memo_send_errors(Key, {throw, R}, Server),
-                    throw(R)
+                    erlang:raise(Class, R, S)
             end
     end.
 


### PR DESCRIPTION
Supress logging the memo error, since all information is now raised
again we are not losing this info.