### PR TITLE
Replace convoluted dict lookup with dialyzer nowarn directive.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [20.3,21,22,23,24]
+        otp_version: [20.3,21,22,23,24,25]
         os: [ubuntu-latest]
 
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,5 @@ jobs:
         run: make test
       - name: XRef
         run: make xref
-#      - name: Dialyzer
-#        run: make dialyzer
+      - name: Dialyzer
+        run: make dialyzer

--- a/src/depcache.erl
+++ b/src/depcache.erl
@@ -407,7 +407,7 @@ get_wait(Key, Server) ->
     Key :: key(),
     Server :: depcache_server(),
     Result :: [{pid(), Tag}],
-    Tag :: atom().
+    Tag :: gen_server:reply_tag().
 	
 get_waiting_pids(Key, Server) ->
     gen_server:call(Server, {get_waiting_pids, Key}, ?MAX_GET_WAIT*1000).
@@ -716,7 +716,7 @@ init(Config) ->
 
 -spec handle_call(Request, From, State) -> Result when 
     Request :: get_tables,
-    From :: {pid(), atom()},
+    From :: {pid(), gen_server:reply_tag()},
     State :: state(),
     Meta_table :: ets:tab(),
     Deps_table :: ets:tab(),
@@ -724,21 +724,21 @@ init(Config) ->
     Result :: {reply, {ok, {Meta_table, Deps_table, Data_table}}, State};
 (Request, From, State) -> Result when 
     Request :: get_wait,
-    From :: {pid(), atom()},
+    From :: {pid(), gen_server:reply_tag()},
     State :: state(),
     Result :: {reply, Reply, state()} | {noreply, state()},
     Reply :: undefined | {ok, term()};
 (Request, From, State) -> Result when
     Request :: {get_waiting_pids, Key},
     Key :: key(),
-    From :: {pid(), atom()},
+    From :: {pid(), gen_server:reply_tag()},
     State :: state(),
     Result :: {reply, [{pid(), Tag}], state()},
-    Tag :: atom();
+    Tag :: gen_server:reply_tag();
 (Request, From, State) -> Result when
     Request :: {get, Key},
     Key :: key(),
-    From :: {pid(), atom()},
+    From :: {pid(), gen_server:reply_tag()},
     State :: state(),
     Result :: {reply, Reply, State},
     Reply :: undefined | {ok, term()};
@@ -746,7 +746,7 @@ init(Config) ->
     Request :: {get, Key, SubKey},
     Key :: key(),
     SubKey :: key(),
-    From :: {pid(), atom()},
+    From :: {pid(), gen_server:reply_tag()},
     State :: state(),
     Result :: {reply, Reply, State},
     Reply :: undefined | {ok, term()};
@@ -756,19 +756,19 @@ init(Config) ->
     Data :: any(),
     MaxAge :: max_age_secs(),
     Depend :: dependencies(),
-    From :: {pid(), atom()},
+    From :: {pid(), gen_server:reply_tag()},
     State :: state(),
     Result :: {reply, Reply, State},
     Reply :: ok;
 (Request, From, State) -> Result when
     Request :: {flush, Key},
     Key :: key(),
-    From :: {pid(), atom()},
+    From :: {pid(), gen_server:reply_tag()},
     State :: state(),
     Result :: {reply, ok, State};
 (Request, From, State) -> Result when	
 	Request :: flush,
-	From :: {pid(), atom()},
+	From :: {pid(), gen_server:reply_tag()},
 	State :: state(),
 	Result :: {reply, ok, State}.
 handle_call(get_tables, _From, State) ->

--- a/src/depcache.erl
+++ b/src/depcache.erl
@@ -1212,10 +1212,14 @@ check_depend(Serial, Depend, DepsTable) ->
     lists:foldl(CheckDepend, true, Depend).
 
 
+%% Don't warn about types in find_value, especially the dict lookup
+%% triggers warnings from dialyzer about the tuple not being an
+%% opaque dict() type.
 -dialyzer({nowarn_function, find_value/2}).
 
 %% @private
 %% @doc Search by value in some set of data.
+
 -spec find_value(Key, Data) -> Result when
 	Key :: key() | integer(),
 	Data :: map() | List | Rsc_list | tuple() | any(),

--- a/src/depcache.erl
+++ b/src/depcache.erl
@@ -1212,9 +1212,10 @@ check_depend(Serial, Depend, DepsTable) ->
     lists:foldl(CheckDepend, true, Depend).
 
 
+-dialyzer({nowarn_function, find_value/2}).
+
 %% @private
 %% @doc Search by value in some set of data.
-
 -spec find_value(Key, Data) -> Result when
 	Key :: key() | integer(),
 	Data :: map() | List | Rsc_list | tuple() | any(),
@@ -1264,9 +1265,7 @@ find_value(Key, Tuple) when is_tuple(Tuple) ->
     Module = element(1, Tuple),
     case Module of
         dict ->
-			{Key1, Value} = Tuple,
-			Dict = dict:append(Key1, Value, dict:new()),
-            case dict:find(Key, Dict) of
+            case dict:find(Key, Tuple) of
                 {ok, Val} ->
                     Val;
                 _ ->


### PR DESCRIPTION
Extra code was added to make Dialyzer pass the dict:find/2 lookup on a tuple that was found to be a dict. This code is now removed and replaced with a dialyzer directive to not warn about the find_value/2 function.