### PR TITLE
Replace dicts with maps (and more)

### DIFF
--- a/test/depcache_tests.erl
+++ b/test/depcache_tests.erl
@@ -25,7 +25,7 @@
 %%     receive after 5000 -> y end.
 
 get_set_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     ?assertEqual(undefined, depcache:get(test_key, C)),
     depcache:set(test_key, 123, C),
@@ -35,7 +35,7 @@ get_set_test() ->
 
 
 flush_all_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     depcache:set(test_key, 123, C),
     depcache:set(test_key2, 123, C),
@@ -51,7 +51,7 @@ flush_all_test() ->
 %% Temporarily disabled - tests works when ran from the zotonic shell, but not from the 'runtests' command.
 
 get_set_maxage_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     ?assertEqual(undefined, depcache:get(xtest_key, C)),
 
@@ -65,7 +65,7 @@ get_set_maxage_test() ->
 
 
 get_set_maxage0_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     ?assertEqual(undefined, depcache:get(test_key, C)),
 
@@ -75,7 +75,7 @@ get_set_maxage0_test() ->
 
 
 get_set_depend_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     ?assertEqual(undefined, depcache:get(test_key, C)),
 
@@ -96,7 +96,7 @@ increase(X) ->
     I.
 
 map_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
     ?assertEqual(undefined, depcache:get(a, b, C)),
     depcache:set(a, #{ b => 1 }, C),
     ?assertEqual({ok, 1}, depcache:get(a, b, C)),
@@ -104,7 +104,7 @@ map_test() ->
 
 
 memo_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     IncreaserFun = fun() ->
                            increase(x)
@@ -118,7 +118,7 @@ memo_test() ->
 
 
 memo_record_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     Fun = fun() -> V = increase(y), #memo{value=V, deps=[dep]} end,
 
@@ -133,7 +133,7 @@ raise_error() ->
     erlang:error(some_error).
 
 memo_raise_test() ->
-    {ok, C} = depcache:start_link([]),
+    {ok, C} = depcache:start_link(#{}),
 
     Fun = fun() -> raise_error() end,
     try

--- a/test/prop_depcache.erl
+++ b/test/prop_depcache.erl
@@ -143,7 +143,7 @@ prop_memo() ->
 
 setup() ->
 	fun() ->
-		{ok, Server} = depcache:start_link([]),
+		{ok, Server} = depcache:start_link(#{}),
 		register(dep, Server),
 		fun() -> 
 			depcache:flush(Server),


### PR DESCRIPTION
This PR is a mashup of several things. I noticed that too late to separate them into several commits :sweat:

* All usages of `dicts` have been replaced with maps (except one, which I'm not sure about).
* The `start_link` functions now also accept maps on top of proplists, and the tests have been changed to use the maps variant. The function `proplists:to_map/1` used to convert proplists intomaps appeared only as late as OTP 24. For that reason, I backported this function (copied from https://github.com/erlang/otp/blob/master/lib/stdlib/src/proplists.erl#L704-L720) into `depcache`, to be usable when running on older (pre-24) OTP versions.
* The configuration given to `start_link` is now validated, that is, config maps (and by extension, proplists) are not allowed to contain keys other than `memory_max` and `callback`, and if present, the values are validated to be either `undefined`, an integer >= 0 for `memory_max`, or a tuple of module, function and arguments (see next two points). If a config is given that is by this definition invalid, a `badarg` error is raised.
* More/corrected/improved typing/specs. Specifically, some types/specs denoted `mfa()` - `{Module, Function, `***`Arity`***`}` - but were actually used in the code as `{Module, Function, `***`Arguments`***`}`.
* The value tuple for the `callback` option can also be given with a single (non-list) value for the arguments, in which case it is reinterpreted to mean a single argument for the given Module:Function. This is ambiguous and therefore questionable, in fact it should be discouraged. The specs provided with this PR still keep that usage open (therefore the `no_warn` directive for `callback/3`), but dialyzer will (should) complain if users use the single non-list variant for `callback`.
* The tick timer has been changed from an interval timer to a timer that is restarted whenever the `tick` message has been received. This removes the need to flush missed ticks from the message queue.