### PR TITLE
fix {depcache,init,1,[{file,\"src/depcache.erl\"},{line,758}]

### DIFF
--- a/src/depcache.erl
+++ b/src/depcache.erl
@@ -762,7 +762,7 @@ init(Config) ->
                 deps_table=ets:new(deps_table, [set, {keypos, 2}, protected, {read_concurrency, true}]),
                 data_table=ets:new(data_table, [set, {keypos, 1}, protected, {read_concurrency, true}])
             };
-        {name, Name} when is_atom(Name) ->
+        Name when is_atom(Name) ->
             #tables{
                 meta_table=ets:new(?NAMED_TABLE(Name, ?META_TABLE_PREFIX),
                                    [set, named_table, {keypos, 2}, protected, {read_concurrency, true}]),


### PR DESCRIPTION
When I did this, the program reported an error:

```
    depcache:start_link(
        ?DEPCACHE_SERVER,
        #{
            memory_max => proplists:get_value(depcache_memory_max, Args)
            , callback => {?MODULE, record_depcache_event, [Args]}
        }
    ).
```

error: 
```
fix {depcache,init,1,[{file,\"src/depcache.erl\"},{line,758}]
```

I'm not sure how to design this method record_depcache_event

Previously it was one parameter, now the latest code is two parameters

https://github.com/zotonic/zotonic/blob/master/apps/zotonic_core/src/support/z_depcache.erl