### PR TITLE
Monitor the process which creates the memo value

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [20.3,21,22,23,24,25]
+        otp_version: [25,26,27]
         os: [ubuntu-latest]
 
     container:

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
 	]},
 	{test, [
 	    {dialyzer, [
-          {plt_extra_apps, [proper]},
+          {plt_extra_apps, [proper, eunit]},
           {warnings, [
               no_return
           ]}

--- a/rebar.config
+++ b/rebar.config
@@ -19,6 +19,7 @@
 	]},
 	{test, [
 	    {dialyzer, [
+          {plt_extra_apps, [proper]},
           {warnings, [
               no_return
           ]}

--- a/test/depcache_tests.erl
+++ b/test/depcache_tests.erl
@@ -154,13 +154,13 @@ memo_premature_kill_test() ->
                                      timer:sleep(500),
                                      done 
                              end,
-                       depcache:memo(Fun, test, C)
+                       depcache:memo(Fun, premature_kill_test, C)
                end,
 
     Pid = spawn(LongTask),
     timer:kill_after(250, Pid),
     timer:sleep(50),
-    ?assertEqual({throw, premature_exit}, depcache:get_wait(test, C)),
+    ?assertEqual({error, premature_exit}, depcache:get_wait(premature_kill_test, C)),
 
     % Check if another process takes over processing in case of pre-mature exits 
     Task = spawn(LongTask),

--- a/test/depcache_tests.erl
+++ b/test/depcache_tests.erl
@@ -145,3 +145,28 @@ memo_raise_test() ->
         ?assertMatch({depcache_tests, raise_error, 0, _}, hd(S))
     end,
     ok.
+
+memo_premature_kill_test() ->
+    {ok, C} = depcache:start_link(#{}),
+
+    LongTask = fun() ->
+                       Fun = fun() ->
+                                     timer:sleep(500),
+                                     done 
+                             end,
+                       depcache:memo(Fun, test, C)
+               end,
+
+    Pid = spawn(LongTask),
+    timer:kill_after(250, Pid),
+    timer:sleep(50),
+    ?assertEqual({throw, premature_exit}, depcache:get_wait(test, C)),
+
+    % Check if another process takes over processing in case of pre-mature exits 
+    Task = spawn(LongTask),
+    timer:kill_after(250, Task),
+    timer:sleep(50),
+    ?assertEqual(done, LongTask()),
+
+    ok.
+

--- a/test/prop_depcache.erl
+++ b/test/prop_depcache.erl
@@ -1,6 +1,14 @@
 -module(prop_depcache).
 -include_lib("proper/include/proper.hrl").
 
+-dialyzer({nowarn_function, prop_set_get/0}).
+-dialyzer({nowarn_function, prop_flush_all/0}).
+-dialyzer({nowarn_function, prop_get_set_maxage/0}).
+-dialyzer({nowarn_function, prop_get_set_maxage_0/0}).
+-dialyzer({nowarn_function, prop_get_set_depend/0}).
+-dialyzer({nowarn_function, prop_get_set_depend_map/0}).
+-dialyzer({nowarn_function, prop_memo/0}).
+
 %%%%%%%%%%%%%%%%%%
 %%% Properties %%%
 %%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
When the process which is creating the memo function is exited prematurely all processes which are waiting will timeout. 

In this PR the process creating the memo value is monitored, when a premature exit is detected, one of the other waiters will take over and try to calculate the memo value.